### PR TITLE
Add option for debugging messages

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,15 @@ USING_VALGRIND=0
 
 FLAGS="-L3p/libs/ -I3p/include/ -Wall -Wextra -g -DUSING_VALGRIND=$USING_VALGRIND"
 
+# pass `--debug` to this script to enable debugging messages
+while test $# != 0
+do
+    case "$1" in
+    --debug) FLAGS="$FLAGS -DDEBUG" ;;
+    esac
+    shift
+done
+
 mkdir temp
 
 mkdir temp/utils

--- a/src/compiler/parse.c
+++ b/src/compiler/parse.c
@@ -491,7 +491,8 @@ static inline TokenKind current(Context *ctx)
 	return current_token(ctx)->kind;
 }
 
-#if 0
+// Compile with -DDEBUG to get debugging messages printed to stderr.
+#ifdef DEBUG
 
 #include <stdio.h>
 


### PR DESCRIPTION
This will make it so that you can turn on debugging messages by passing `--debug` to `build.sh`.

from u/anon25783 with love~
